### PR TITLE
Added image dimension fingerprinting and fixed small JS fingerprinting issue

### DIFF
--- a/fingerprint_db.js
+++ b/fingerprint_db.js
@@ -38,6 +38,13 @@ var fingerprints = [
         },
     },
     {
+        'name': "TPLINK Archer C7 AC1750 (Logged Out)",
+        'fingerprints': [["/login/top1_1.jpg",280,87],["/login/top2.jpg",770,3]],
+        'callback': function( ip ) {
+            // Insert exploit here
+        },
+    },
+    {
         'name': "Epson WF-3520 Printer",
         'fingerprints': ["/PRESENTATION/IMAGE/EPSONLOGO.PNG","/PRESENTATION/IMAGE/SEPARATOR.PNG","/PRESENTATION/IMAGE/EC_ILL.PNG","/PRESENTATION/IMAGE/GCP_ILL.PNG","/PRESENTATION/IMAGE/C_B_ILL.PNG","/PRESENTATION/IMAGE/B_C_ILL.PNG","/PRESENTATION/IMAGE/AIRP_ILL.PNG","/PRESENTATION/IMAGE/PRTINFO_ILL.PNG","/PRESENTATION/IMAGE/EC_BTN.PNG","/PRESENTATION/IMAGE/GCP_BTN.PNG","/PRESENTATION/IMAGE/C_B_BTN.PNG","/PRESENTATION/IMAGE/B_C_BTN.PNG","/PRESENTATION/IMAGE/AIRP_BTN.PNG","/PRESENTATION/IMAGE/PRTINFO_BTN.PNG"],
         'callback': function( ip ) {

--- a/sonar_fingerprint_generator/src/browser_action/js/main.js
+++ b/sonar_fingerprint_generator/src/browser_action/js/main.js
@@ -14,13 +14,13 @@ function copycode() {
 document.getElementById("copy2clipboardbutton").addEventListener("click", copycode);
 
 function remove_duplicates(arr) {
-    var obj = {};
-    for (var i = 0; i < arr.length; i++) {
-        obj[arr[i]] = true;
-    }
-    arr = [];
-    for (var key in obj) {
-        arr.push(key);
-    }
-    return arr;
+    var prims = {"boolean":{}, "number":{}, "string":{}}, objs = [];
+
+    return arr.filter(function(item) {
+        var type = typeof item;
+        if(type in prims)
+            return prims[type].hasOwnProperty(item) ? false : (prims[type][item] = true);
+        else
+            return objs.indexOf(item) >= 0 ? false : objs.push(item);
+    });
 }

--- a/sonar_fingerprint_generator/src/inject/inject.js
+++ b/sonar_fingerprint_generator/src/inject/inject.js
@@ -11,7 +11,7 @@ function get_resource_array( document_ref ) {
   var prints = [];
   for( var i = 0; i < document_ref.images.length; i++ ){
     if( document_ref.images[i].src !== undefined && document_ref.images[i].src !== null ) {
-      prints.push( document_ref.images[i].src );
+      prints.push( [ document_ref.images[i].src, document_ref.images[i].naturalWidth, document_ref.images[i].naturalHeight ] );
     }
   }
   for( var i = 0; i < document_ref.styleSheets.length; i++ ){
@@ -20,7 +20,11 @@ function get_resource_array( document_ref ) {
     }
   }
   for( var i = 0; i < prints.length; i++ ){
-    prints[i] = get_relative_path( prints[i] );
+    if (prints[i] instanceof Array) {
+      prints[i][0] = get_relative_path( prints[i][0] );
+    } else {
+      prints[i] = get_relative_path( prints[i] );  
+    }
   }
   return prints;
 }

--- a/sonar_fingerprint_generator/src/inject/inject.js
+++ b/sonar_fingerprint_generator/src/inject/inject.js
@@ -23,7 +23,7 @@ function get_resource_array( document_ref ) {
     }
   }
   for( var i = 0; i < document_ref.scripts.length; i++ ){
-    if( document_ref.scripts[i].src !== undefined && document_ref.scripts[i].src !== null ) {
+    if( document_ref.scripts[i].src !== undefined && document_ref.scripts[i].src !== null && document_ref.scripts[i].src.length > 0 ) {
       prints.push( document_ref.scripts[i].src );
     }
   }


### PR DESCRIPTION
Because different versions of devices may use the same image names but physically different images, adding and checking for the dimensions of the images in the fingerprint allows for more precise device identification. It's optional, and right now to use the additional feature an image in a fingerprint gets represented as an array (`["url", width, height]`) instead of just a string. Example:

`"/images/logo.jpg"`

becomes

`["/images/logo.jpg", 200, 50]`

The fingerprinting extension now returns dimensions by default as well.

Also corrected a small problem where the fingerprinter was detecting inline JS and representing it as a "/" in the fingerprints list.

_Note:_ I didn't bump the versions, as I figured you could do that when/if you accepted the PR and merged any other changes you wanted. :)
